### PR TITLE
Remove running VM

### DIFF
--- a/demo/sc_demo_vm.tf
+++ b/demo/sc_demo_vm.tf
@@ -64,7 +64,7 @@ resource "hypercore_nic" "vlan_all" {
 
 resource "hypercore_vm_power_state" "demo_vm" {
   vm_uuid = hypercore_vm.demo_vm.id
-  state   = "SHUTOFF" # available states are: SHUTOFF, RUNNING, PAUSED
+  state   = "RUNNING" # available states are: SHUTOFF, RUNNING, PAUSED
   depends_on = [
     hypercore_disk.os,
     hypercore_disk.iso,

--- a/internal/provider/hypercore_vm_power_state_resource.go
+++ b/internal/provider/hypercore_vm_power_state_resource.go
@@ -287,6 +287,17 @@ func (r *HypercoreVMPowerStateResource) Delete(ctx context.Context, req resource
 	}
 
 	// Extra implementation not needed
+	// We use this to ensure VM is shutdown, before it is deleted.
+	// After VM is shutdown, disks can be deleted.
+	// Code assumes there is no reason to remove hypercore_vm_power_state resource from Terraform plan,
+	// while keeping hypercore_vm resource.
+	restClient := *r.client
+	vm_uuid := data.VmUUID.ValueString()
+	err := ShutdownVM(ctx, vm_uuid, &restClient)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to shutdown VM before, got error: %s", err))
+		return
+	}
 
 	// If applicable, this is a great opportunity to initialize any necessary
 	// provider client data and make a call using it.

--- a/internal/provider/hypercore_vm_resource.go
+++ b/internal/provider/hypercore_vm_resource.go
@@ -501,9 +501,9 @@ func (r *HypercoreVMResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	restClient := *r.client
 	vm_uuid := data.Id.ValueString()
-	err := shutdownVM(ctx, vm_uuid, &restClient)
+	err := ShutdownVM(ctx, vm_uuid, &restClient)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete shutdown VM, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to shutdown VM, got error: %s", err))
 		return
 	}
 
@@ -520,7 +520,7 @@ func (r *HypercoreVMResource) ImportState(ctx context.Context, req resource.Impo
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func shutdownVM(ctx context.Context, vmUUID string, restClient *utils.RestClient) diag.Diagnostic {
+func ShutdownVM(ctx context.Context, vmUUID string, restClient *utils.RestClient) diag.Diagnostic {
 	currentState, err := utils.GetVMPowerState(vmUUID, *restClient)
 	if err != nil {
 		return err


### PR DESCRIPTION
PR fixes removal of running VM. Problem is we try to delete also disks while the VM is running, and this delete disk fails.

The hypercore_vm_power_state and hypercore_vm_power_state have 1:1 relationship. So we can use hypercore_vm_power_state.Delete to shutdown VM, before it disks and VM are deleted.