### PR TITLE
Nicer diagnostic on error

### DIFF
--- a/internal/provider/hypercore_disk_resource.go
+++ b/internal/provider/hypercore_disk_resource.go
@@ -110,6 +110,8 @@ func (r *HypercoreDiskResource) Configure(ctx context.Context, req resource.Conf
 }
 
 func (r *HypercoreDiskResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreDiskResource CREATE")
 	var data HypercoreDiskResourceModel
 	// var readData HypercoreDiskResourceModel
@@ -221,6 +223,8 @@ func (r *HypercoreDiskResource) Create(ctx context.Context, req resource.CreateR
 }
 
 func (r *HypercoreDiskResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreDiskResource READ")
 	var data HypercoreDiskResourceModel
 	// Read Terraform prior state data into the model
@@ -257,6 +261,8 @@ func (r *HypercoreDiskResource) Read(ctx context.Context, req resource.ReadReque
 }
 
 func (r *HypercoreDiskResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreDiskResource UPDATE")
 	var data_state HypercoreDiskResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -350,6 +356,8 @@ func (r *HypercoreDiskResource) Update(ctx context.Context, req resource.UpdateR
 }
 
 func (r *HypercoreDiskResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreDiskResource DELETE")
 	var data HypercoreDiskResourceModel
 
@@ -379,6 +387,8 @@ func (r *HypercoreDiskResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *HypercoreDiskResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreDiskResource IMPORT_STATE")
 	idParts := strings.Split(req.ID, ":")
 	if len(idParts) != 3 {

--- a/internal/provider/hypercore_iso_resource.go
+++ b/internal/provider/hypercore_iso_resource.go
@@ -92,6 +92,8 @@ func (r *HypercoreISOResource) Configure(ctx context.Context, req resource.Confi
 }
 
 func (r *HypercoreISOResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreNicResource CREATE")
 	var data HypercoreISOResourceModel
 
@@ -181,6 +183,8 @@ func (r *HypercoreISOResource) Create(ctx context.Context, req resource.CreateRe
 }
 
 func (r *HypercoreISOResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreISOResource READ")
 	var data HypercoreISOResourceModel
 	// Read Terraform prior state data into the model
@@ -214,6 +218,8 @@ func (r *HypercoreISOResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *HypercoreISOResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreISOResource UPDATE")
 	var data_state HypercoreISOResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -257,6 +263,8 @@ func (r *HypercoreISOResource) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *HypercoreISOResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreISOResource DELETE")
 	var data HypercoreISOResourceModel
 
@@ -286,6 +294,8 @@ func (r *HypercoreISOResource) Delete(ctx context.Context, req resource.DeleteRe
 }
 
 func (r *HypercoreISOResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreISOResource IMPORT_STATE")
 
 	vdUUID := req.ID

--- a/internal/provider/hypercore_nic_resource.go
+++ b/internal/provider/hypercore_nic_resource.go
@@ -96,6 +96,8 @@ func (r *HypercoreNicResource) Configure(ctx context.Context, req resource.Confi
 }
 
 func (r *HypercoreNicResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreNicResource CREATE")
 	var data HypercoreNicResourceModel
 	// var readData HypercoreNicResourceModel
@@ -136,6 +138,8 @@ func (r *HypercoreNicResource) Create(ctx context.Context, req resource.CreateRe
 }
 
 func (r *HypercoreNicResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreNicResource READ")
 	var data HypercoreNicResourceModel
 	// Read Terraform prior state data into the model
@@ -172,6 +176,8 @@ func (r *HypercoreNicResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *HypercoreNicResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreNicResource UPDATE")
 	var data_state HypercoreNicResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -219,6 +225,8 @@ func (r *HypercoreNicResource) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *HypercoreNicResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreNicResource DELETE")
 	var data HypercoreNicResourceModel
 
@@ -248,6 +256,8 @@ func (r *HypercoreNicResource) Delete(ctx context.Context, req resource.DeleteRe
 }
 
 func (r *HypercoreNicResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreNicResource IMPORT_STATE")
 	idParts := strings.Split(req.ID, ":")
 	if len(idParts) != 3 {

--- a/internal/provider/hypercore_nodes_data_source.go
+++ b/internal/provider/hypercore_nodes_data_source.go
@@ -104,6 +104,8 @@ func (d *hypercoreNodesDataSource) Configure(_ context.Context, req datasource.C
 
 // Read refreshes the Terraform state with the latest data.
 func (d *hypercoreNodesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	var conf hypercoreNodesDataSourceModel
 	req.Config.Get(ctx, &conf)
 	// use float64, because this is the type of loaded json data

--- a/internal/provider/hypercore_remote_cluster_connections_data_source.go
+++ b/internal/provider/hypercore_remote_cluster_connections_data_source.go
@@ -115,6 +115,8 @@ func (d *hypercoreRemoteClusterConnectionsDataSource) Configure(_ context.Contex
 
 // Read refreshes the Terraform state with the latest data.
 func (d *hypercoreRemoteClusterConnectionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	var conf hypercoreRemoteClusterConnectionsDataSourceModel
 	req.Config.Get(ctx, &conf)
 

--- a/internal/provider/hypercore_virtual_disk_resource.go
+++ b/internal/provider/hypercore_virtual_disk_resource.go
@@ -90,6 +90,8 @@ func (r *HypercoreVirtualDiskResource) Configure(ctx context.Context, req resour
 }
 
 func (r *HypercoreVirtualDiskResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVirtualDiskResource CREATE")
 	var data HypercoreVirtualDiskResourceModel
 
@@ -138,6 +140,8 @@ func (r *HypercoreVirtualDiskResource) Create(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVirtualDiskResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVirtualDiskResource READ")
 	var data HypercoreVirtualDiskResourceModel
 	// Read Terraform prior state data into the model
@@ -170,6 +174,8 @@ func (r *HypercoreVirtualDiskResource) Read(ctx context.Context, req resource.Re
 }
 
 func (r *HypercoreVirtualDiskResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVirtualDiskResource UPDATE")
 	var data_state HypercoreVirtualDiskResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -207,6 +213,8 @@ func (r *HypercoreVirtualDiskResource) Update(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVirtualDiskResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVirtualDiskResource DELETE")
 	var data HypercoreVirtualDiskResourceModel
 
@@ -236,6 +244,8 @@ func (r *HypercoreVirtualDiskResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVirtualDiskResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVirtualDiskResource IMPORT_STATE")
 
 	vdUUID := req.ID

--- a/internal/provider/hypercore_vm_boot_order_resource.go
+++ b/internal/provider/hypercore_vm_boot_order_resource.go
@@ -90,6 +90,8 @@ func (r *HypercoreVMBootOrderResource) Configure(ctx context.Context, req resour
 }
 
 func (r *HypercoreVMBootOrderResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMBootOrderResource CREATE")
 	var data HypercoreVMBootOrderResourceModel
 
@@ -139,6 +141,8 @@ func (r *HypercoreVMBootOrderResource) Create(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVMBootOrderResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMBootOrderResource READ")
 	var data HypercoreVMBootOrderResourceModel
 	// Read Terraform prior state data into the model
@@ -184,6 +188,8 @@ func (r *HypercoreVMBootOrderResource) Read(ctx context.Context, req resource.Re
 }
 
 func (r *HypercoreVMBootOrderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMBootOrderResource UPDATE")
 	var data_state HypercoreVMBootOrderResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -228,6 +234,8 @@ func (r *HypercoreVMBootOrderResource) Update(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVMBootOrderResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMBootOrderResource DELETE")
 	var data HypercoreVMBootOrderResourceModel
 
@@ -250,6 +258,8 @@ func (r *HypercoreVMBootOrderResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVMBootOrderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMBootOrderResource IMPORT_STATE")
 
 	vmUUID := req.ID

--- a/internal/provider/hypercore_vm_power_state_resource.go
+++ b/internal/provider/hypercore_vm_power_state_resource.go
@@ -94,6 +94,8 @@ func (r *HypercoreVMPowerStateResource) Configure(ctx context.Context, req resou
 }
 
 func (r *HypercoreVMPowerStateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMPowerStateResource CREATE")
 	var data HypercoreVMPowerStateResourceModel
 
@@ -167,6 +169,8 @@ func (r *HypercoreVMPowerStateResource) Create(ctx context.Context, req resource
 }
 
 func (r *HypercoreVMPowerStateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMPowerStateResource READ")
 	var data HypercoreVMPowerStateResourceModel
 	// Read Terraform prior state data into the model
@@ -200,6 +204,8 @@ func (r *HypercoreVMPowerStateResource) Read(ctx context.Context, req resource.R
 }
 
 func (r *HypercoreVMPowerStateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMPowerStateResource UPDATE")
 	var data_state HypercoreVMPowerStateResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -276,6 +282,8 @@ func (r *HypercoreVMPowerStateResource) Update(ctx context.Context, req resource
 }
 
 func (r *HypercoreVMPowerStateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMPowerStateResource DELETE")
 	var data HypercoreVMPowerStateResourceModel
 
@@ -309,6 +317,8 @@ func (r *HypercoreVMPowerStateResource) Delete(ctx context.Context, req resource
 }
 
 func (r *HypercoreVMPowerStateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMPowerStateResource IMPORT_STATE")
 
 	vmUUID := req.ID

--- a/internal/provider/hypercore_vm_replication_resource.go
+++ b/internal/provider/hypercore_vm_replication_resource.go
@@ -119,6 +119,8 @@ func (r *HypercoreVMReplicationResource) Configure(ctx context.Context, req reso
 }
 
 func (r *HypercoreVMReplicationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMReplicationResource CREATE")
 	var data HypercoreVMReplicationResourceModel
 
@@ -188,6 +190,8 @@ func (r *HypercoreVMReplicationResource) Create(ctx context.Context, req resourc
 }
 
 func (r *HypercoreVMReplicationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMReplicationResource READ")
 	var data HypercoreVMReplicationResourceModel
 	// Read Terraform prior state data into the model
@@ -226,6 +230,8 @@ func (r *HypercoreVMReplicationResource) Read(ctx context.Context, req resource.
 }
 
 func (r *HypercoreVMReplicationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMReplicationResource UPDATE")
 	var data_state HypercoreVMReplicationResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -279,6 +285,8 @@ func (r *HypercoreVMReplicationResource) Update(ctx context.Context, req resourc
 }
 
 func (r *HypercoreVMReplicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMReplicationResource DELETE")
 	var data HypercoreVMReplicationResourceModel
 
@@ -301,6 +309,8 @@ func (r *HypercoreVMReplicationResource) Delete(ctx context.Context, req resourc
 }
 
 func (r *HypercoreVMReplicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMReplicationResource IMPORT_STATE")
 
 	replicationUUID := req.ID

--- a/internal/provider/hypercore_vm_resource.go
+++ b/internal/provider/hypercore_vm_resource.go
@@ -320,6 +320,8 @@ func (r *HypercoreVMResource) doCreateLogic(data *HypercoreVMResourceModel, ctx 
 }
 
 func (r *HypercoreVMResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMResource CREATE")
 	var data HypercoreVMResourceModel
 
@@ -354,6 +356,8 @@ func (r *HypercoreVMResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 func (r *HypercoreVMResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMResource READ")
 	var data HypercoreVMResourceModel
 	// Read Terraform prior state data into the model
@@ -414,6 +418,8 @@ func (r *HypercoreVMResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *HypercoreVMResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMResource UPDATE")
 	var data_state HypercoreVMResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -489,6 +495,8 @@ func (r *HypercoreVMResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 func (r *HypercoreVMResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMResource DELETE")
 	var data HypercoreVMResourceModel
 

--- a/internal/provider/hypercore_vm_snapshot.go
+++ b/internal/provider/hypercore_vm_snapshot.go
@@ -96,6 +96,8 @@ func (r *HypercoreVMSnapshotResource) Configure(ctx context.Context, req resourc
 }
 
 func (r *HypercoreVMSnapshotResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotResource CREATE")
 	var data HypercoreVMSnapshotResourceModel
 
@@ -160,6 +162,8 @@ func (r *HypercoreVMSnapshotResource) Create(ctx context.Context, req resource.C
 }
 
 func (r *HypercoreVMSnapshotResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotResource READ")
 	var data HypercoreVMSnapshotResourceModel
 	// Read Terraform prior state data into the model
@@ -217,6 +221,8 @@ func (r *HypercoreVMSnapshotResource) Update(ctx context.Context, req resource.U
 }
 
 func (r *HypercoreVMSnapshotResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotResource DELETE")
 	var data HypercoreVMSnapshotResourceModel
 
@@ -246,6 +252,8 @@ func (r *HypercoreVMSnapshotResource) Delete(ctx context.Context, req resource.D
 }
 
 func (r *HypercoreVMSnapshotResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotResource IMPORT_STATE")
 
 	snapUUID := req.ID

--- a/internal/provider/hypercore_vm_snapshot_schedule.go
+++ b/internal/provider/hypercore_vm_snapshot_schedule.go
@@ -156,6 +156,8 @@ func (r *HypercoreVMSnapshotScheduleResource) Configure(ctx context.Context, req
 }
 
 func (r *HypercoreVMSnapshotScheduleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotScheduleResource CREATE")
 	var data HypercoreVMSnapshotScheduleResourceModel
 
@@ -262,6 +264,8 @@ func (r *HypercoreVMSnapshotScheduleResource) Create(ctx context.Context, req re
 }
 
 func (r *HypercoreVMSnapshotScheduleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotScheduleResource READ")
 	var data HypercoreVMSnapshotScheduleResourceModel
 	// Read Terraform prior state data into the model
@@ -330,6 +334,8 @@ func (r *HypercoreVMSnapshotScheduleResource) Read(ctx context.Context, req reso
 }
 
 func (r *HypercoreVMSnapshotScheduleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotScheduleResource UPDATE")
 	var data_state HypercoreVMSnapshotScheduleResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data_state)...)
@@ -441,6 +447,8 @@ func (r *HypercoreVMSnapshotScheduleResource) Update(ctx context.Context, req re
 }
 
 func (r *HypercoreVMSnapshotScheduleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotScheduleResource DELETE")
 	var data HypercoreVMSnapshotScheduleResourceModel
 
@@ -471,6 +479,7 @@ func (r *HypercoreVMSnapshotScheduleResource) Delete(ctx context.Context, req re
 
 func (r *HypercoreVMSnapshotScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// NOTE: Do we need import state or would it be better to have a data source instead?
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
 
 	tflog.Info(ctx, "TTRT HypercoreVMSnapshotScheduleResource IMPORT_STATE")
 

--- a/internal/provider/hypercore_vms_data_source.go
+++ b/internal/provider/hypercore_vms_data_source.go
@@ -171,6 +171,8 @@ func (d *hypercoreVMsDataSource) Configure(_ context.Context, req datasource.Con
 
 // Read refreshes the Terraform state with the latest data.
 func (d *hypercoreVMsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	var conf hypercoreVMsDataSourceModel
 	req.Config.Get(ctx, &conf)
 	filter_name := conf.FilterName.ValueString()

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -74,6 +74,8 @@ func (p *HypercoreProvider) Schema(ctx context.Context, req provider.SchemaReque
 }
 
 func (p *HypercoreProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	defer utils.RecoverDiagnostics(ctx, &resp.Diagnostics)
+
 	scHost := os.Getenv("HC_HOST")
 	scUsername := os.Getenv("HC_USERNAME")
 	scPassword := os.Getenv("HC_PASSWORD")

--- a/internal/utils/helper.go
+++ b/internal/utils/helper.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -329,4 +330,11 @@ func ValidateHTTP(httpUri string, path string) diag.Diagnostic {
 	}
 
 	return nil
+}
+
+func RecoverDiagnostics(ctx context.Context, diags *diag.Diagnostics) {
+	if r := recover(); r != nil {
+		err := fmt.Errorf("Terraform provider got an unexpected error during execution: %v", r)
+		*diags = append(*diags, diag.NewErrorDiagnostic("Unexpected error", err.Error()))
+	}
 }

--- a/internal/utils/iso.go
+++ b/internal/utils/iso.go
@@ -64,21 +64,24 @@ func CreateISO(
 	readyForInsert bool,
 	binaryData []byte,
 	ctx context.Context,
-) (string, map[string]any) {
+) (string, map[string]any, error) {
 	payload := map[string]any{
 		"name":           name,
 		"size":           len(binaryData),
 		"readyForInsert": readyForInsert,
 	}
-	taskTag, _, _ := restClient.CreateRecord(
+	taskTag, _, errorObj := restClient.CreateRecord(
 		"/rest/v1/ISO",
 		payload,
 		-1,
 	)
+	if taskTag == nil || taskTag.CreatedUUID == "" {
+		return "", nil, errorObj
+	}
 	taskTag.WaitTask(restClient, ctx)
 	isoUUID := taskTag.CreatedUUID
 	iso := GetISOByUUID(restClient, isoUUID)
-	return isoUUID, *iso
+	return isoUUID, *iso, nil
 }
 
 func GetISOByUUID(

--- a/internal/utils/rest_client.go
+++ b/internal/utils/rest_client.go
@@ -204,7 +204,9 @@ func (rc *RestClient) Login() {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		panic(fmt.Errorf("authentication failed with status code: %d", resp.StatusCode))
+		respBytes, _ := io.ReadAll(resp.Body)
+		respStr := string(respBytes)
+		panic(fmt.Errorf("authentication failed with HTTP status code: %d, body: %v", resp.StatusCode, respStr))
 	}
 
 	if respJson, ok := rc.ToJson(resp).(map[string]any); ok {


### PR DESCRIPTION
When somethings goes wrong show nice error message instead of stack trace.

VirtualDisk create is nice example, where HTTP response already contains `Virtual disk with provided filename already exists: 7d51d54b-0c60-4ddb-8e6f-b8c0e05c6de1, this virtual disk must be deleted before it can be uploaded again.`. This message we just pass trough.

Trying to re-upload ISO image, HyperCore error message is `An internal error occurred`. Here we just add a "hint" about "heck if ISO with this name already exists".