### PR TITLE
Preserve mac address logic for VM clone

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -67,6 +67,7 @@ resource "hypercore_vm" "myvm" {
       ssh_authorized_keys = "",
       ssh_import_id       = "",
     })
+    preserve_mac_address = true # User wants to preserve mac address from the source machine (Default is false)
   }
 }
 
@@ -102,7 +103,7 @@ output "vm_uuid" {
 ### Optional
 
 - `affinity_strategy` (Object) VM node affinity. (see [below for nested schema](#nestedatt--affinity_strategy))
-- `clone` (Object) Clone options if the VM is being created as a clone. The `source_vm_uuid` is the UUID of the VM used for cloning, <br>`user_data` and `meta_data` are used for the cloud init data. (see [below for nested schema](#nestedatt--clone))
+- `clone` (Attributes) Clone options if the VM is being created as a clone. The `source_vm_uuid` is the UUID of the VM used for cloning, <br>`user_data` and `meta_data` are used for the cloud init data. (see [below for nested schema](#nestedatt--clone))
 - `description` (String) Description of this VM
 - `import` (Attributes) Options for importing a VM through a SMB server or some other HTTP location. <br>Use server, username, password for SMB or http_uri for some other HTTP location. Parameters path and file_name are always **required** (see [below for nested schema](#nestedatt--import))
 - `memory` (Number) Memory (RAM) size in `MiB`: If the cloned VM was already created <br>and it's memory was modified, the cloned VM will be rebooted (either gracefully or forcefully)
@@ -127,11 +128,14 @@ Optional:
 <a id="nestedatt--clone"></a>
 ### Nested Schema for `clone`
 
+Required:
+
+- `source_vm_uuid` (String)
+
 Optional:
 
 - `meta_data` (String)
 - `preserve_mac_address` (Boolean)
-- `source_vm_uuid` (String)
 - `user_data` (String)
 
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -130,6 +130,7 @@ Optional:
 Optional:
 
 - `meta_data` (String)
+- `preserve_mac_address` (Boolean)
 - `source_vm_uuid` (String)
 - `user_data` (String)
 

--- a/examples/resources/hypercore_vm/resource.tf
+++ b/examples/resources/hypercore_vm/resource.tf
@@ -36,6 +36,7 @@ resource "hypercore_vm" "myvm" {
       ssh_authorized_keys = "",
       ssh_import_id       = "",
     })
+    preserve_mac_address = true # User wants to preserve mac address from the source machine (Default is false)
   }
 }
 

--- a/internal/provider/hypercore_vm_resource.go
+++ b/internal/provider/hypercore_vm_resource.go
@@ -62,9 +62,10 @@ type ImportModel struct {
 }
 
 type CloneModel struct {
-	SourceVMUUID types.String `tfsdk:"source_vm_uuid"`
-	UserData     types.String `tfsdk:"user_data"`
-	MetaData     types.String `tfsdk:"meta_data"`
+	SourceVMUUID       types.String `tfsdk:"source_vm_uuid"`
+	UserData           types.String `tfsdk:"user_data"`
+	MetaData           types.String `tfsdk:"meta_data"`
+	PreserveMacAddress types.Bool   `tfsdk:"preserve_mac_address"`
 }
 
 type AffinityStrategyModel struct {
@@ -155,9 +156,10 @@ The provider will currently try to shutdown VM only before VM delete.`,
 					"`user_data` and `meta_data` are used for the cloud init data.",
 				Optional: true,
 				AttributeTypes: map[string]attr.Type{
-					"source_vm_uuid": types.StringType,
-					"user_data":      types.StringType,
-					"meta_data":      types.StringType,
+					"source_vm_uuid":       types.StringType,
+					"user_data":            types.StringType,
+					"meta_data":            types.StringType,
+					"preserve_mac_address": types.BoolType,
 				},
 			},
 			"affinity_strategy": schema.ObjectAttribute{
@@ -219,16 +221,19 @@ func (r *HypercoreVMResource) Configure(ctx context.Context, req resource.Config
 func getVMStruct(data *HypercoreVMResourceModel, vmDescription *string, vmTags *[]string) *utils.VM {
 	// Gets VM structure from Utils.VM, sends parameters based on which VM create logic is being called
 	sourceVMUUID, userData, metaData := "", "", ""
+	preserveMacAddress := false
 	if data.Clone != nil {
 		sourceVMUUID = data.Clone.SourceVMUUID.ValueString()
 		userData = data.Clone.UserData.ValueString()
 		metaData = data.Clone.MetaData.ValueString()
+		preserveMacAddress = data.Clone.PreserveMacAddress.ValueBool()
 	}
 	vmStruct := utils.GetVMStruct(
 		data.Name.ValueString(),
 		sourceVMUUID,
 		userData,
 		metaData,
+		preserveMacAddress,
 		vmDescription,
 		vmTags,
 		data.VCPU.ValueInt32Pointer(),

--- a/internal/provider/hypercore_vm_resource.go
+++ b/internal/provider/hypercore_vm_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -150,16 +151,26 @@ The provider will currently try to shutdown VM only before VM delete.`,
 					},
 				},
 			},
-			"clone": schema.ObjectAttribute{
+			"clone": schema.SingleNestedAttribute{
 				MarkdownDescription: "" +
 					"Clone options if the VM is being created as a clone. The `source_vm_uuid` is the UUID of the VM used for cloning, <br>" +
 					"`user_data` and `meta_data` are used for the cloud init data.",
 				Optional: true,
-				AttributeTypes: map[string]attr.Type{
-					"source_vm_uuid":       types.StringType,
-					"user_data":            types.StringType,
-					"meta_data":            types.StringType,
-					"preserve_mac_address": types.BoolType,
+				Attributes: map[string]schema.Attribute{
+					"source_vm_uuid": schema.StringAttribute{
+						Required: true,
+					},
+					"user_data": schema.StringAttribute{
+						Optional: true,
+					},
+					"meta_data": schema.StringAttribute{
+						Optional: true,
+					},
+					"preserve_mac_address": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
+					},
 				},
 			},
 			"affinity_strategy": schema.ObjectAttribute{

--- a/internal/provider/tests/acceptance/hypercore_vm_resource_clone_acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vm_resource_clone_acc_test.go
@@ -125,6 +125,7 @@ resource "hypercore_vm" "test" {
 	source_vm_uuid = %[2]q
 	user_data = ""
 	meta_data = ""
+	preserve_mac_address = false
   }
 }
 `, vm_name, source_vm_uuid, requested_power_state)


### PR DESCRIPTION
Closes #48 
What was done in this PR:
- Preserve mac address logic added to VM clone
- Now Clone logic keeps the net devices from source and user can specific to keep MAC addresses from source VM