### PR TITLE
Fix node affinity

### DIFF
--- a/demo/sc_demo_vm.tf
+++ b/demo/sc_demo_vm.tf
@@ -4,7 +4,7 @@
 # After we have virtual disk, we use it to create new VM from it
 # First create VM without any disk.
 resource "hypercore_vm" "demo_vm" {
-  group       = "testtf"
+  tags       = ["testtf"]
   name        = local.vm_name
   description = "Demo Ana's cloned VM"
   vcpu        = 4

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -40,8 +40,9 @@ resource "hypercore_vm" "empty-vm" {
   name        = "empty-vm"
   description = "some description"
 
-  vcpu   = 4
-  memory = 4096 # MiB
+  vcpu              = 4
+  memory            = 4096 # MiB
+  affinity_strategy = {}
 }
 
 data "hypercore_vms" "clone_source_vm" {
@@ -55,6 +56,7 @@ resource "hypercore_vm" "myvm" {
 
   vcpu                   = 4
   memory                 = 4096 # MiB
+  affinity_strategy      = {}
   snapshot_schedule_uuid = data.hypercore_vms.clone_source_vm.vms.0.snapshot_schedule_uuid
 
   clone = {
@@ -76,8 +78,9 @@ resource "hypercore_vm" "import-from-smb" {
   name        = "imported-vm"
   description = "some description"
 
-  vcpu   = 4
-  memory = 4096 # MiB
+  vcpu              = 4
+  memory            = 4096 # MiB
+  affinity_strategy = {}
 
   import = {
     server    = "10.5.11.39"
@@ -102,7 +105,7 @@ output "vm_uuid" {
 
 ### Optional
 
-- `affinity_strategy` (Object) VM node affinity. (see [below for nested schema](#nestedatt--affinity_strategy))
+- `affinity_strategy` (Attributes) (see [below for nested schema](#nestedatt--affinity_strategy))
 - `clone` (Attributes) Clone options if the VM is being created as a clone. The `source_vm_uuid` is the UUID of the VM used for cloning, <br>`user_data` and `meta_data` are used for the cloud init data. (see [below for nested schema](#nestedatt--clone))
 - `description` (String) Description of this VM
 - `import` (Attributes) Options for importing a VM through a SMB server or some other HTTP location. <br>Use server, username, password for SMB or http_uri for some other HTTP location. Parameters path and file_name are always **required** (see [below for nested schema](#nestedatt--import))

--- a/examples/resources/hypercore_vm/resource.tf
+++ b/examples/resources/hypercore_vm/resource.tf
@@ -9,8 +9,9 @@ resource "hypercore_vm" "empty-vm" {
   name        = "empty-vm"
   description = "some description"
 
-  vcpu   = 4
-  memory = 4096 # MiB
+  vcpu              = 4
+  memory            = 4096 # MiB
+  affinity_strategy = {}
 }
 
 data "hypercore_vms" "clone_source_vm" {
@@ -24,6 +25,7 @@ resource "hypercore_vm" "myvm" {
 
   vcpu                   = 4
   memory                 = 4096 # MiB
+  affinity_strategy      = {}
   snapshot_schedule_uuid = data.hypercore_vms.clone_source_vm.vms.0.snapshot_schedule_uuid
 
   clone = {
@@ -45,8 +47,9 @@ resource "hypercore_vm" "import-from-smb" {
   name        = "imported-vm"
   description = "some description"
 
-  vcpu   = 4
-  memory = 4096 # MiB
+  vcpu              = 4
+  memory            = 4096 # MiB
+  affinity_strategy = {}
 
   import = {
     server    = "10.5.11.39"

--- a/internal/provider/tests/acceptance/hypercore_vm_resource__snapshot_schedule__acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vm_resource__snapshot_schedule__acc_test.go
@@ -99,6 +99,7 @@ resource "hypercore_vm" "test" {
   memory = 4096
   description = "testtf-vm-description"
   // snapshot_schedule_uuid = ""
+  affinity_strategy = {}
 }
 `, vm_name)
 }

--- a/internal/provider/tests/acceptance/hypercore_vm_resource_clone_acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vm_resource_clone_acc_test.go
@@ -96,6 +96,7 @@ resource "hypercore_vm" "test" {
 	meta_data = ""
 	preserve_mac_address = false
   }
+  affinity_strategy = {}
 }
 `, vm_name, source_vm_uuid, requested_power_state)
 }

--- a/internal/provider/tests/acceptance/hypercore_vm_resource_import_acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vm_resource_import_acc_test.go
@@ -48,6 +48,7 @@ resource "hypercore_vm" "test" {
     path      = %[5]q
     file_name = %[6]q
   }
+  affinity_strategy = {}
 }
 `, vm_name, smb_server, smb_username, smb_password, smb_path, smb_filename, requested_power_state)
 }


### PR DESCRIPTION
Fix for #45 .
Provider needs to read `PreferredNodeUUID` from HyperCore, after VM is started.

Complication is that VM is started by `hypercore_vm_power_state`, and this one cannot update `hypercore_vm`. This means we need to call `terraform apply` twice - on second invocation `hypercore_vm` will notice `PreferredNodeUUID` was changed on HyperCore side, and will write this value into terraform state.

Second complication is `affinity_strategy` is now mandatory. At least it can be just `affinity_strategy={}`.