### PR TITLE
Add VM IP address to hypercore_vms datasource

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,15 +28,15 @@ Add needed variables/secrets to github project:
   ```
 
 Prior to running acceptance tests we need to setup:
-  - Virtual machine  
-    - name integration-test-vm  
-    - has two disks  
-      - type VIRTIO (1.2GB, 2.4GB)  
-    - has two nics  
-      - first of type INTEL_E1000, vlan 10, MAC 7C:4C:58:12:34:56  
-      - second of type VIRTIO, vlan ALL  
-    - boot order is configured as [disk, nic]  
-  - Virtual disk (as standalone not attached to the testing VM)  
-  - Add names and UUIDs to the env.txt file in /tests/acceptance/setup directory  
-    - There are multiple env-*.txt files, for different test HyperCore clusters.  
+  - Virtual machine
+    - name integration-test-vm
+    - has two disks
+      - type VIRTIO (1.2GB, 2.4GB)
+    - has two nics
+      - first of type INTEL_E1000, vlan 10, MAC 7C:4C:58:12:34:56
+      - second of type VIRTIO, vlan ALL
+    - boot order is configured as [disk, nic]
+  - Virtual disk (as standalone not attached to the testing VM)
+  - Add names and UUIDs to the env.txt file in /tests/acceptance/setup directory
+    - There are multiple env-*.txt files, for different test HyperCore clusters.
   - Virtual machine needs to be powered off

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -82,6 +82,7 @@ Read-Only:
 
 Read-Only:
 
+- `ipv4_addresses` (List of String) IPv4 addresses
 - `mac_address` (String) MAC address
 - `type` (String) type
 - `uuid` (String) UUID

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -51,6 +51,7 @@ Read-Only:
 - `description` (String)
 - `disks` (Attributes List) List of disks (see [below for nested schema](#nestedatt--vms--disks))
 - `name` (String)
+- `nics` (Attributes List) List of NICs (see [below for nested schema](#nestedatt--vms--nics))
 - `power_state` (String)
 - `snapshot_schedule_uuid` (String) UUID of the applied snapshot schedule for creating automated snapshots
 - `uuid` (String)
@@ -74,3 +75,14 @@ Read-Only:
 - `slot` (Number) slot
 - `type` (String) type
 - `uuid` (String) UUID
+
+
+<a id="nestedatt--vms--nics"></a>
+### Nested Schema for `vms.nics`
+
+Read-Only:
+
+- `mac_address` (String) MAC address
+- `type` (String) type
+- `uuid` (String) UUID
+- `vlan` (Number) vlan

--- a/internal/provider/tests/acceptance/hypercore_vms_data_source_acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vms_data_source_acc_test.go
@@ -51,6 +51,20 @@ func TestAccHypercoreVMsDatasource_stopped(t *testing.T) {
 					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.1.type", "VIRTIO_DISK"),
 					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.1.slot", "1"),
 					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.1.size", "2.4"),
+
+					// VM on XLAB NUC
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.#", "1"),
+					// resource.TestCheckResourceAttrSet("data.hypercore_vms.test", "vms.0.nics.0.uuid"),
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.type", "INTEL_E1000"),
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.vlan", "10"),
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.mac_address", "7C:4C:58:12:34:56"),
+
+					// VM on CI VSNS https://10.5.11.205/
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.#", "1"),
+					resource.TestCheckResourceAttrSet("data.hypercore_vms.test", "vms.0.nics.0.uuid"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.type", "VIRTIO"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.vlan", "0"),
+					resource.TestCheckResourceAttrSet("data.hypercore_vms.test", "vms.0.nics.0.mac_address"),
 				),
 			},
 		},

--- a/internal/provider/tests/acceptance/hypercore_vms_data_source_acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vms_data_source_acc_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+/*
+func testCheckListIsPresentEvenIfEmpty(resourceName string, attrName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		// val, ok := rs.Primary.Attributes[attrName+".#"]
+		_, ok = rs.Primary.Attributes[attrName+".#"]
+		if !ok {
+			return fmt.Errorf("attribute %s is not set", attrName)
+		}
+		// val is a string representing the number of elements
+		// if val != "0" {
+		// 	return fmt.Errorf("expected %s to be empty, got length: %s", attrName, val)
+		// }
+		return nil
+	}
+}
+*/
+
+func TestAccHypercoreVMsDatasource_stopped(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testConfig_stopped("integration-test-vm"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.name", "integration-test-vm"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.memory", "4096"),
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.vcpu", "1"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.power_state", "SHUTOFF"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.#", "2"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.0.type", "VIRTIO_DISK"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.0.slot", "0"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.0.size", "1.2"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.1.type", "VIRTIO_DISK"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.1.slot", "1"),
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.disks.1.size", "2.4"),
+				),
+			},
+		},
+	})
+}
+
+func testConfig_stopped(vm_name string) string {
+	return fmt.Sprintf(`
+data "hypercore_vms" "test" {
+  name = %[1]q
+}
+`, vm_name)
+}
+
+/*
+TODO - test VM IP is actually returned.
+To test this, we need a bootable ISO, with qemu-geust-agent.
+Or similar qcow2 image.
+func x_TestAccHypercoreVMsDatasource_running(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testConfig_running_step1(),
+			},
+			{
+				Config: testConfig_running_step2(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.name", "testtf-datasource-vms-running"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.memory", "4096"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.vcpu", "4"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.power_state", "RUNNING"),
+				),
+			},
+		},
+	})
+}
+
+func testConfig_running_step1() string {
+	return fmt.Sprintf(`
+# bootable ISO, it needs to get IP from DHCP, and needs to contain qemu guest agent.
+resource "hypercore_iso" "liveiso" {
+  name       = "Porteus-XFCE-v5.0-x86_64.iso"
+  source_url = "https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0/Porteus-XFCE-v5.0-x86_64.iso"
+}
+
+resource "hypercore_vm" "test" {
+  tags        = ["testtf", "vms-datasource-running"]
+  name        = "testtf-vms-datasource-running"
+  description = "testtf-vms-datasource-running description"
+
+  vcpu              = 4
+  memory            = 4096 # MiB
+  affinity_strategy = {}
+}
+
+resource "hypercore_disk" "liveiso" {
+  vm_uuid  = hypercore_vm.test.id
+  type     = "IDE_CDROM"
+  iso_uuid = hypercore_iso.liveiso.id
+  size     = 0.364904448
+}
+`)
+}
+
+func testConfig_running_step2() string {
+	return fmt.Sprintf(`
+# bootable ISO, it needs to get IP from DHCP, and needs to contain qemu guest agent.
+resource "hypercore_iso" "liveiso" {
+  name       = "Porteus-XFCE-v5.0-x86_64.iso"
+  source_url = "https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0/Porteus-XFCE-v5.0-x86_64.iso"
+}
+
+resource "hypercore_vm" "test" {
+  tags        = ["testtf", "vms-datasource-running"]
+  name        = "testtf-vms-datasource-running"
+  description = "testtf-vms-datasource-running description"
+
+  vcpu              = 4
+  memory            = 4096 # MiB
+  affinity_strategy = {}
+}
+
+resource "hypercore_disk" "liveiso" {
+  vm_uuid  = hypercore_vm.test.id
+  type     = "IDE_CDROM"
+  iso_uuid = hypercore_iso.liveiso.id
+  size     = 0.364904448
+}
+
+data "hypercore_vms" "test" {
+  name = "testtf-vms-datasource-running"
+}
+`)
+}
+*/

--- a/internal/provider/tests/acceptance/hypercore_vms_data_source_acc_test.go
+++ b/internal/provider/tests/acceptance/hypercore_vms_data_source_acc_test.go
@@ -58,13 +58,14 @@ func TestAccHypercoreVMsDatasource_stopped(t *testing.T) {
 					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.type", "INTEL_E1000"),
 					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.vlan", "10"),
 					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.mac_address", "7C:4C:58:12:34:56"),
+					// resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.ipv4_addresses.#", "0"),
 
 					// VM on CI VSNS https://10.5.11.205/
 					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.#", "1"),
 					resource.TestCheckResourceAttrSet("data.hypercore_vms.test", "vms.0.nics.0.uuid"),
 					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.type", "VIRTIO"),
 					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.vlan", "0"),
-					resource.TestCheckResourceAttrSet("data.hypercore_vms.test", "vms.0.nics.0.mac_address"),
+					resource.TestCheckResourceAttr("data.hypercore_vms.test", "vms.0.nics.0.ipv4_addresses.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
The `hypercore_vms` is extended to include list of NIC devices. The IPv4 addresses are included into datasource output.

Fixes #69 