### PR TITLE
Empty API response handling to virtual disk module

### DIFF
--- a/internal/provider/hypercore_disk_resource.go
+++ b/internal/provider/hypercore_disk_resource.go
@@ -207,6 +207,7 @@ func (r *HypercoreDiskResource) Create(ctx context.Context, req resource.CreateR
 			*r.client,
 			attachPayload,
 			sourceVirtualDiskID,
+			data.VmUUID.ValueString(),
 			ctx,
 		)
 		if err != nil {

--- a/internal/utils/vm.go
+++ b/internal/utils/vm.go
@@ -245,7 +245,6 @@ func (vc *VM) SendImportRequest(restClient RestClient, source map[string]any) *T
 		payload,
 		-1,
 	)
-	//panic(fmt.Sprintf("neki neki: %d, %v", statusCode, err))
 	return taskTag
 }
 func (vc *VM) Import(restClient RestClient, source map[string]any, ctx context.Context) map[string]any {


### PR DESCRIPTION
There's an issue with Hypercore API sometimes returning empty Task UUID if an action didn't execute on the API side
Closes #73 