### PR TITLE
Optionally wait on VM to get IP address

### DIFF
--- a/docs/resources/vm_power_state.md
+++ b/docs/resources/vm_power_state.md
@@ -60,6 +60,7 @@ import {
 ### Optional
 
 - `force_shutoff` (Boolean) Set to `true` if you want to put the VM into the `SHUTOFF` state by force. This option will only be taken into account when `state` is set to `SHUTOFF`. Default is `false`.
+- `wait_for_guest_net_timeout` (Number) Set to non-zero value to wait on guest OS to report guest IP address to hypervisor.<br>The guest OS needs to have guest tools installed (qemu-guest-agent).
 
 ### Read-Only
 

--- a/internal/provider/tests/acceptance/setup/env-x11.txt
+++ b/internal/provider/tests/acceptance/setup/env-x11.txt
@@ -1,9 +1,9 @@
 HC_VM_SHUTDOWN_TIMEOUT=30
 
-SOURCE_VM_UUID="c6ce1356-7487-4fd3-97f4-bff1c3b3d86a"
+SOURCE_VM_UUID="0ad1bb9b-470c-466f-ae88-797630118415"
 # testtf-ci-virtual-disk.img - https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/generic_alpine-3.21.2-x86_64-bios-tiny-r0.qcow2
-EXISTING_VDISK_UUID="ac8c5105-6c42-474b-a445-61fc32e177e9"
+EXISTING_VDISK_UUID="3ee7b833-4c7e-4410-82ab-43ddd8b101d6"
 SOURCE_VM_NAME="integration-test-vm"
-SOURCE_NIC_UUID="e51c9076-b1ec-438a-8485-d653b627cdcb"
-SOURCE_DISK_UUID="3c4db35c-c38c-4cdb-999a-46632058d29a"
+SOURCE_NIC_UUID="36c8e4a8-9434-4549-bf24-d825cbbe7a06"
+SOURCE_DISK_UUID="3a065638-c01b-43f4-b414-15d5ebf34b1e"
 

--- a/local/assets/alma-10/meta-data
+++ b/local/assets/alma-10/meta-data
@@ -1,0 +1,6 @@
+#cloud-config
+instance-id: 
+local-hostname: my-hostname
+network-interfaces: |
+  auto eth0
+  iface eth0 inet dhcp

--- a/local/assets/alma-10/user-data
+++ b/local/assets/alma-10/user-data
@@ -1,0 +1,10 @@
+#cloud-config
+
+# https://wiki.almalinux.org/cloud/Generic-cloud-on-local.html#create-a-snapshot-from-the-image
+
+ssh_pwauth: true # sshd service will be configured to accept password authentication method
+password: testp # Set a password for almalinux
+chpasswd:
+  expire: false # Don't ask for password reset after the first log-in
+ssh_authorized_keys: # Add your ssh public key for publickey authentication
+  - ssh-ed25519 ...

--- a/local/main.tf
+++ b/local/main.tf
@@ -10,8 +10,9 @@ terraform {
 }
 
 locals {
-  src_vm_name = "testtf-src-empty"
-  vm_name = "testtf-justin-affinity"
+  # Use image AlmaLinux-10-GenericCloud-10.1-20251125.0.x86_64_v2.qcow2
+  src_vm_name = "testtf-src-alma-10"
+  vm_name = "testtf-wait-net"
 }
 
 provider "hypercore" {}
@@ -24,8 +25,16 @@ resource "hypercore_vm" "myvm" {
   name = local.vm_name
   clone = {
     source_vm_uuid = data.hypercore_vms.srcvm.vms.0.uuid
-    user_data = ""
-    meta_data = ""
+    # meta_data = templatefile("assets/meta-data.ubuntu-22.04.yml.tftpl", {
+    #   name = local.vm_name,
+    # })
+    # user_data = templatefile("assets/user-data.ubuntu-22.04.yml.tftpl", {
+    #   name                = local.vm_name,
+    #   ssh_authorized_keys = "",
+    #   ssh_import_id       = "justinc1",
+    # })
+    user_data = file("assets/alma-10/user-data")
+    meta_data = file("assets/alma-10/meta-data")
   }
   # TODO - are computed, on HC3 side
   memory = 1024
@@ -42,4 +51,5 @@ resource "hypercore_vm_power_state" "myvm" {
   vm_uuid = hypercore_vm.myvm.id
   # state   = "SHUTOFF" # available states are: SHUTOFF, RUNNING, PAUSED
   state   = "RUNNING" # available states are: SHUTOFF, RUNNING, PAUSED
+  wait_for_guest_net_timeout = 120
 }


### PR DESCRIPTION
PR add optional wait on VM to get IP address. This is enabled by setting `wait_for_guest_net_timeout` in `hypercore_vm_power_state` resource. Unit for `wait_for_guest_net_timeout` are seconds.

Partially fixes #96 - the tests are missing. I tested code manually, using Alma 10 cloud image.

PR also fixes nice ACPI VM shutdown bug. The rest API does return a taskTag if we start VM. But it does not return a taskTag for a nice VM shutdown (`"actionType":"SHUTDOWN"`). This resulted in provider failure - provider noticed VM is still running after `"actionType":"SHUTDOWN"`, and thought shutdown request was somehow ignored. In fact provider just need to wait a bit. Wait time is limited to 300 sec.

CI failure in TestAccHypercoreVMsDatasource_stopped - the test VM has more disks/nics than our test expects. I think because the same VM name is used in ansible collection tests.

